### PR TITLE
Configure Tailwind with Weber palette

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-weber-orange: var(--weber-orange);
+  --color-weber-navy: var(--weber-navy);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -46,6 +48,8 @@
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
+  --weber-orange: #FF6600;
+  --weber-navy: #001F3F;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -80,6 +84,8 @@
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
+  --weber-orange: #FF6600;
+  --weber-navy: #001F3F;
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);

--- a/components.json
+++ b/components.json
@@ -4,7 +4,7 @@
   "rsc": false,
   "tsx": true,
   "tailwind": {
-    "config": "",
+    "config": "tailwind.config.ts",
     "css": "app/globals.css",
     "baseColor": "neutral",
     "cssVariables": true,

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from "tailwindcss"
+
+export default {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        "weber-orange": "#FF6600",
+        "weber-navy": "#001F3F",
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config


### PR DESCRIPTION
## Summary
- add Tailwind config with Weber brand colors
- update shadcn components config to reference Tailwind config
- set up PostCSS plugins and expose Weber colors in global styles

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_b_68acd889dc488333a749f5a4e4923ccc